### PR TITLE
Re-enable explicit render parameter

### DIFF
--- a/admin-options.php
+++ b/admin-options.php
@@ -45,7 +45,7 @@ function rcfwc_keys_updated() {
 function rcfwc_admin_script_enqueue( $hook ) {
 	// Only load on this plugin settings page
 	if ( isset( $_GET['page'] ) && $_GET['page'] === 'recaptcha-woo/admin-options.php' ) {
-		wp_register_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js?hl=' . get_locale() );
+		wp_register_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js?render=explicit&hl=' . get_locale() );
 		wp_enqueue_script( 'recaptcha' );
 		wp_enqueue_style( 'rcfwc-admin', plugins_url( 'css/admin.css', __FILE__ ), array(), '1.4.3' );
 	}

--- a/recaptcha-woo.php
+++ b/recaptcha-woo.php
@@ -59,7 +59,7 @@ if(get_option('rcfwc_scripts_all', true)) {
 }
 function rcfwc_script_enqueue() {
 	wp_enqueue_script( 'rcfwc-js', plugins_url( '/js/rcfwc.js', __FILE__ ), array('jquery'), '1.0', array('strategy' => 'defer'));
-	wp_enqueue_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js?hl=' . get_locale(), array(), null, array('strategy' => 'defer'));
+	wp_enqueue_script( 'recaptcha', 'https://www.google.com/recaptcha/api.js?render=explicit&hl=' . get_locale(), array(), null, array('strategy' => 'defer'));
 }
 add_action("wp_enqueue_scripts", "rcfwc_script");
 function rcfwc_script() {


### PR DESCRIPTION
Force explicit rendering of the reCAPTCHA element, previously removed in V1.4.5
This prevents automatic rendering on load and allows renderRecaptcha() to run as intended.