### PR TITLE
support woocommerce_review_order_before_submit

### DIFF
--- a/recaptcha-woo.php
+++ b/recaptcha-woo.php
@@ -290,8 +290,8 @@ if(!empty(get_option('rcfwc_key')) && !empty(get_option('rcfwc_secret'))) {
 
   	// Woo Checkout
   	if( get_option('rcfwc_key') && get_option('rcfwc_woo_checkout') ) {
-		if(empty(get_option('rcfwc_woo_checkout_pos')) || get_option('rcfwc_woo_checkout_pos') == "beforepay") {
-			add_action('woocommerce_review_order_before_payment', 'rcfwc_field_checkout', 10);
+		if(empty(get_option('rcfwc_woo_checkout_pos')) || get_option('rcfwc_woo_checkout_pos') == "beforepay" || get_option('rcfwc_woo_checkout_pos') == "beforesubmit") {
+			add_action('woocommerce_review_order_before_submit', 'rcfwc_field_checkout', 10);
 			add_filter('render_block_woocommerce/checkout-payment-block', 'rcfwc_render_pre_block', 999, 1); // Before Payment block.
 		} elseif(get_option('rcfwc_woo_checkout_pos') == "afterpay") {
 			add_action('woocommerce_review_order_after_payment', 'rcfwc_field_checkout', 10);
@@ -302,9 +302,6 @@ if(!empty(get_option('rcfwc_key')) && !empty(get_option('rcfwc_secret'))) {
 		} elseif(get_option('rcfwc_woo_checkout_pos') == "afterbilling") {
 			add_action('woocommerce_after_checkout_billing_form', 'rcfwc_field_checkout', 10);
 			add_filter('render_block_woocommerce/checkout-shipping-methods-block', 'rcfwc_render_pre_block', 999, 1); // Before Shipping Methods block.
-		} elseif(get_option('rcfwc_woo_checkout_pos') == "beforesubmit") {
-			add_action('woocommerce_review_order_before_submit', 'rcfwc_field_checkout', 10);
-			add_filter('render_block_woocommerce/checkout-actions-block', 'rcfwc_render_pre_block', 999, 1); // Before Actions block, not sure if this option is still supported.
 		}
   		add_action('woocommerce_checkout_process', 'rcfwc_checkout_check');
 		add_action('woocommerce_store_api_checkout_update_order_from_request', 'rcfwc_checkout_block_check', 10, 2);


### PR DESCRIPTION
Updated the plugin so checkout reCAPTCHA now renders before the Place Order button via `woocommerce_review_order_before_submit`.

What I changed
- In recaptcha-woo.php, I changed the default checkout placement branch to hook:
add_action('woocommerce_review_order_before_submit', 'rcfwc_field_checkout', 10);
- I also kept backward compatibility for any saved legacy value by treating both beforepay and beforesubmit as this same placement.
- Removed the now-redundant separate beforesubmit branch.

reCAPTCHA will now appear directly before the submit/checkout button on classic WooCommerce checkout (the review_order_before_submit hook location).